### PR TITLE
Minor changes to 'MovieList' functionalities

### DIFF
--- a/MobileChallenge01/Application/Delegate/SceneDelegate.swift
+++ b/MobileChallenge01/Application/Delegate/SceneDelegate.swift
@@ -18,8 +18,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let navigationController = UINavigationController()
         
-        navigationController.hidesBarsOnSwipe = true
-        
         navigationController.setCustomAppearance()
         
         coordinator = Coordinator(navigationController: navigationController)

--- a/MobileChallenge01/Screens/MovieList/MovieListViewController.swift
+++ b/MobileChallenge01/Screens/MovieList/MovieListViewController.swift
@@ -30,16 +30,17 @@ class MovieListViewController: UIViewController {
         
         view.addSubview(tableViewController.view)
         
-        viewModel.getPopularMovies { result in
-            switch result {
-            case .success(let movies):
-                self.viewModel.updateMovieList(with: movies)
-                DispatchQueue.main.async {
-                    self.tableViewController.reloadData()
-                }
-                
-            case .failure(let error):
-                print("ERROR: \(error)")
+        Task {
+            await viewModel.getPopularMovies()
+            
+            DispatchQueue.main.async {
+                self.tableViewController.reloadData()
+            }
+            
+            await viewModel.getPosterForAllMovies()
+            
+            DispatchQueue.main.async {
+                self.tableViewController.reloadData()
             }
         }
     }
@@ -68,13 +69,13 @@ extension MovieListViewController: UITableViewDataSource {
             return UITableViewCell()
         }
         
-        guard let movieModel = viewModel.getMovieData(for: indexPath) else {
+        guard let movieData = viewModel.getMovieData(for: indexPath) else {
             return movieCell
         }
         
-        movieCell.setPoster(movieModel.poster)
-        movieCell.setTitle(movieModel.title)
-        movieCell.setReleaseDate(movieModel.releaseDate)
+        movieCell.setPoster(movieData.poster)
+        movieCell.setTitle(movieData.title)
+        movieCell.setReleaseDate(movieData.releaseDate)
         
         return movieCell
     }

--- a/MobileChallenge01/Screens/Shared/Model/Movie.swift
+++ b/MobileChallenge01/Screens/Shared/Model/Movie.swift
@@ -9,6 +9,7 @@ import UIKit.UIImage
 
 struct Movie {
     let poster: UIImage?
+    let posterPath: String?
     let title: String
     let overview: String
     let releaseDate: String

--- a/MobileChallenge01/Screens/Shared/Model/Movie.swift
+++ b/MobileChallenge01/Screens/Shared/Model/Movie.swift
@@ -7,12 +7,24 @@
 
 import UIKit.UIImage
 
-struct Movie {
-    let poster: UIImage?
+class Movie {
+    let id: Int
+    var poster: UIImage?
     let posterPath: String?
     let title: String
     let overview: String
     let releaseDate: String
     let popularity: Double
     let genres: [String]
+    
+    init(id: Int, poster: UIImage? = nil, posterPath: String?, title: String, overview: String, releaseDate: String, popularity: Double, genres: [String]) {
+        self.id = id
+        self.poster = poster
+        self.posterPath = posterPath
+        self.title = title
+        self.overview = overview
+        self.releaseDate = releaseDate
+        self.popularity = popularity
+        self.genres = genres
+    }
 }

--- a/MobileChallenge01/Screens/Shared/Model/MovieList.swift
+++ b/MobileChallenge01/Screens/Shared/Model/MovieList.swift
@@ -5,10 +5,10 @@
 //  Created by Rafael Basso on 07/02/23.
 //
 
-import Foundation
+import UIKit.UIImage
 
-struct MovieList {
-    private let movies: [Movie]
+class MovieList {
+    private var movies: [Movie]
     
     init(_ movies: [Movie]) {
         self.movies = movies
@@ -21,6 +21,11 @@ extension MovieList {
         if index > (count - 1) { return nil }
         
         return self.movies[index]
+    }
+    
+    func createNewList(from movieArray: [Movie]) {
+        self.movies.removeAll()
+        self.movies = movieArray
     }
 }
 

--- a/MobileChallenge01/Screens/Shared/Model/MovieList.swift
+++ b/MobileChallenge01/Screens/Shared/Model/MovieList.swift
@@ -28,4 +28,8 @@ extension MovieList {
     var count: Int {
         movies.count
     }
+    
+    var allMovies: [Movie] {
+        movies
+    }
 }

--- a/MobileChallenge01/Services/Network/Movies/MovieEndpoint.swift
+++ b/MobileChallenge01/Services/Network/Movies/MovieEndpoint.swift
@@ -1,9 +1,17 @@
 import Foundation
 import NetworkLayer
 
+enum PosterSize: String {
+    case w45
+    case w300
+    case w500
+    case original
+}
+
 enum MovieEndpoint {
     case popular
     case genres
+    case poster(size: PosterSize = .original, path: String)
 }
 
 extension MovieEndpoint: Endpoint {
@@ -27,16 +35,23 @@ extension MovieEndpoint: Endpoint {
             return "/3/movie/popular"
         case .genres:
             return "/3/genre/movie/list"
+        case .poster(let size, let path):
+            return "/t/p/\(size)/\(path)"
         }
     }
     
-    var query: String {
-        return "api_key=\(acessToken)"
+    var query: String? {
+        switch self {
+        case .popular, .genres:
+            return "api_key=\(acessToken)"
+        case .poster:
+            return nil
+        }
     }
     
     var method: NetworkLayer.HTTPMethod {
         switch self {
-        case .popular, .genres:
+        case .popular, .genres, .poster:
             return .get
         }
     }

--- a/MobileChallenge01/Services/Network/Movies/MovieEndpoint.swift
+++ b/MobileChallenge01/Services/Network/Movies/MovieEndpoint.swift
@@ -26,7 +26,12 @@ extension MovieEndpoint: Endpoint {
     }
     
     var host: String {
-        return "api.themoviedb.org"
+        switch self {
+        case .popular, .genres:
+            return "api.themoviedb.org"
+        case .poster:
+            return "image.tmdb.org"
+        }
     }
     
     var path: String {
@@ -36,7 +41,7 @@ extension MovieEndpoint: Endpoint {
         case .genres:
             return "/3/genre/movie/list"
         case .poster(let size, let path):
-            return "/t/p/\(size)/\(path)"
+            return "/t/p/\(size)\(path)"
         }
     }
     

--- a/MobileChallenge01/Services/Network/Movies/MovieService.swift
+++ b/MobileChallenge01/Services/Network/Movies/MovieService.swift
@@ -18,7 +18,7 @@ struct MovieService: HTTPClient, MovieServiceable {
     
     private func handleRequest<T: Decodable>(endpoint: Endpoint, responseModel: T.Type) async -> Result<T, RequestError> {
         do {
-            let response = try await sendRequest(endpoint: endpoint, responseModel: responseModel.self)
+            let response = try await sendRequest(endpoint: endpoint, decoding: responseModel)
             return .success(response)
             
         } catch {

--- a/MobileChallenge01/Services/Network/Movies/MovieService.swift
+++ b/MobileChallenge01/Services/Network/Movies/MovieService.swift
@@ -1,32 +1,28 @@
-import Foundation
+import UIKit
 import NetworkLayer
 
 struct MovieService: HTTPClient, MovieServiceable {
-    func getPopular() async -> Result<PopularResponseModel, RequestError> {
+    func getPopular() async -> Result<PopularResponseModel, Error> {
         let endpoint = MovieEndpoint.popular
         let responseModel = PopularResponseModel.self
-        
-        return await handleRequest(endpoint: endpoint, responseModel: responseModel)
+        return await makeRequest(endpoint: endpoint, responseModel: responseModel)
     }
     
-    func getGenres() async -> Result<GenreResponseModel, RequestError> {
+    func getGenres() async -> Result<GenreResponseModel, Error> {
         let endpoint = MovieEndpoint.genres
         let responseModel = GenreResponseModel.self
-        
-        return await handleRequest(endpoint: endpoint, responseModel: responseModel)
+        return await makeRequest(endpoint: endpoint, responseModel: responseModel)
     }
     
-    private func handleRequest<T: Decodable>(endpoint: Endpoint, responseModel: T.Type) async -> Result<T, RequestError> {
+
+extension MovieService {
+    private func makeRequest<T: Decodable>(endpoint: Endpoint, responseModel: T.Type) async -> Result<T, Error> {
         do {
             let response = try await sendRequest(endpoint: endpoint, decoding: responseModel)
             return .success(response)
             
         } catch {
-            if let requestError = error as? RequestError {
-                return .failure(requestError)
-            }
+            return .failure(error)
         }
-        
-        return .failure(.unknown)
     }
 }

--- a/MobileChallenge01/Services/Network/Movies/MovieService.swift
+++ b/MobileChallenge01/Services/Network/Movies/MovieService.swift
@@ -1,6 +1,10 @@
 import UIKit
 import NetworkLayer
 
+enum MovieServiceError: Error {
+    case badResponseData
+}
+
 struct MovieService: HTTPClient, MovieServiceable {
     func getPopular() async -> Result<PopularResponseModel, Error> {
         let endpoint = MovieEndpoint.popular
@@ -14,6 +18,20 @@ struct MovieService: HTTPClient, MovieServiceable {
         return await makeRequest(endpoint: endpoint, responseModel: responseModel)
     }
     
+    func getPoster(filePath: String, size: PosterSize = .original) async -> Result<UIImage, Error> {
+        let endpoint = MovieEndpoint.poster(size: size, path: filePath)
+        do {
+            let responseData = try await sendRequest(endpoint: endpoint)
+            guard let posterImage = UIImage(data: responseData) else {
+                return .failure(MovieServiceError.badResponseData)
+            }
+            return .success(posterImage)
+            
+        } catch {
+            return .failure(error)
+        }
+    }
+}
 
 extension MovieService {
     private func makeRequest<T: Decodable>(endpoint: Endpoint, responseModel: T.Type) async -> Result<T, Error> {

--- a/MobileChallenge01/Services/Network/Movies/MovieServiceable.swift
+++ b/MobileChallenge01/Services/Network/Movies/MovieServiceable.swift
@@ -1,7 +1,8 @@
-import Foundation
+import UIKit
 import NetworkLayer
 
 protocol MovieServiceable {
-    func getPopular() async -> Result<PopularResponseModel, RequestError>
-    func getGenres() async -> Result<GenreResponseModel, RequestError>
+    func getPopular() async -> Result<PopularResponseModel, Error>
+    func getGenres() async -> Result<GenreResponseModel, Error>
+    func getPoster(filePath: String, size: PosterSize) async -> Result<UIImage, Error>
 }

--- a/MobileChallenge01/Services/Repository/Movie/MovieRepositoreable.swift
+++ b/MobileChallenge01/Services/Repository/Movie/MovieRepositoreable.swift
@@ -1,5 +1,6 @@
-import Foundation
+import UIKit
 
 protocol MovieRepositoreable {
     func getPopularMovies() async -> Result<[Movie], Error>
+    func getMoviePoster(movie: Movie, size: PosterSize) async -> UIImage?
 }

--- a/MobileChallenge01/Services/Repository/Movie/MovieRepositoreable.swift
+++ b/MobileChallenge01/Services/Repository/Movie/MovieRepositoreable.swift
@@ -2,5 +2,5 @@ import UIKit
 
 protocol MovieRepositoreable {
     func getPopularMovies() async -> Result<[Movie], Error>
-    func getMoviePoster(movie: Movie, size: PosterSize) async -> UIImage?
+    func getMoviePoster(for movie: Movie, size: PosterSize) async -> UIImage?
 }

--- a/MobileChallenge01/Services/Repository/Movie/MovieRepository.swift
+++ b/MobileChallenge01/Services/Repository/Movie/MovieRepository.swift
@@ -24,7 +24,7 @@ struct MovieRepository: MovieRepositoreable {
         }
     }
     
-    func getMoviePoster(movie: Movie, size: PosterSize = .original) async -> UIImage? {
+    func getMoviePoster(for movie: Movie, size: PosterSize) async -> UIImage? {
         guard let posterPath = movie.posterPath else {
             return nil
         }
@@ -64,6 +64,7 @@ extension MovieRepository {
             let associatedGenres = genres.filter { serviceMovie.genreIDS.contains($0.id) }
             
             let movie = Movie(
+                id: serviceMovie.id,
                 poster: nil,
                 posterPath: serviceMovie.posterPath,
                 title: serviceMovie.title,

--- a/MobileChallenge01/Services/Repository/Movie/MovieRepository.swift
+++ b/MobileChallenge01/Services/Repository/Movie/MovieRepository.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 struct MovieRepository: MovieRepositoreable {
     typealias DataType = Movie
@@ -49,6 +49,7 @@ extension MovieRepository {
             
             let movie = Movie(
                 poster: nil,
+                posterPath: serviceMovie.posterPath,
                 title: serviceMovie.title,
                 overview: serviceMovie.overview,
                 releaseDate: serviceMovie.releaseDate,

--- a/MobileChallenge01/Services/Repository/Movie/MovieRepository.swift
+++ b/MobileChallenge01/Services/Repository/Movie/MovieRepository.swift
@@ -23,6 +23,22 @@ struct MovieRepository: MovieRepositoreable {
             return .failure(error)
         }
     }
+    
+    func getMoviePoster(movie: Movie, size: PosterSize = .original) async -> UIImage? {
+        guard let posterPath = movie.posterPath else {
+            return nil
+        }
+        
+        let response = await service.getPoster(filePath: posterPath, size: size)
+        
+        switch response {
+        case .success(let poster):
+            return poster
+            
+        case .failure:
+            return nil
+        }
+    }
 }
 
 extension MovieRepository {

--- a/NetworkLayer/Sources/NetworkLayer/Core/Endpoint.swift
+++ b/NetworkLayer/Sources/NetworkLayer/Core/Endpoint.swift
@@ -4,7 +4,7 @@ public protocol Endpoint {
     var scheme: String { get }
     var host: String { get }
     var path: String { get }
-    var query: String { get }
+    var query: String? { get }
     var method: HTTPMethod { get }
     var header: [String: String]? { get }
     var body: [String: String]? { get }


### PR DESCRIPTION
- refactor(SceneDelegate): removed navigation controller 'hideBarsOnSwipe'.
- refactor(NetworkLayer/Endpoint): 'query' is now an optional.
- refactor(MovieEndpoint): enum now supports requests for poster images.
- refactor(NetworkLayer/HTTPClient): 'sendRequest' now has a better separation of concerns via function overloading.
- refactor(MovieService): 'handleRequest' is now updated with latest 'NetworkLayer/HTTPClient' methods.
- feat(MovieServiceable): added 'getPoster' method.
- refactor(MovieService): created method 'makeRequest' to remove duplicated code.
- feat(MovieService): implemented method 'getPoster'.
- feat(Movie): added 'posterPath' attribute.
- refactor(MovieRepository): 'translateDomainModels' method now set a value for 'Movie' attribute 'posterPath'.
- feat(MovieRepository): created method 'getMoviePoster'.
- feat(MovieRepositoreable): added 'getMoviePoster' to protocol.
- feat(MovieList): added 'allMovies' computed variable.
- refactor(MovieRepositoreable): changed 'getMoviePoster' parameter.
- refactor(MovieEndpoint): changed 'host' for image related cases.
- refactor(Movie & MovieList): both are now classes.
- refactor(MovieListViewModel): refactored methods to fetch API data from repository.
- refactor: movie request methods now reflect view model.
